### PR TITLE
fix black - py39 is not a valid target version

### DIFF
--- a/styles/black/default.toml
+++ b/styles/black/default.toml
@@ -15,4 +15,4 @@ exclude = '''
 '''
 include = '\.pyi?$'
 line-length = 88
-target-version = ["py38", "py39"]
+target-version = ["py38"]


### PR DESCRIPTION
# What Changed

## Fixed

- fixed black style - py39 is not a valid target version
